### PR TITLE
feat(vector): update port number and add JSON resonse to search-index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean: ## Clean the temporary files.
 	rm -rf .ruff_cache	
 
 # Make does not like interpreting : in the target name, so we use a variable
-API_CMD=poetry run uvicorn api.main:app --host 0.0.0.0 --port 8080 --reload
+API_CMD=poetry run uvicorn api.main:app --host 0.0.0.0 --port 8088 --reload
 
 run-vector-store: ## Run the vectore store and API
 	$(API_CMD)

--- a/api/models/search_index.py
+++ b/api/models/search_index.py
@@ -4,7 +4,7 @@ The models in this module are used to represent the response
 returned by the API.
 """
 
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel
 
 
 class SearchIndexRequest(BaseModel):
@@ -33,9 +33,7 @@ class SearchIndexItem(BaseModel):
     two_digit_code: str
 
 
-class SearchIndexResponse(
-    RootModel[list[SearchIndexItem]]
-):  # pylint: disable=too-few-public-methods
+class SearchIndexResponse(BaseModel):
     """Model representing the vector store search index multi response."""
 
-    pass  # pylint: disable=unnecessary-pass
+    results: list[SearchIndexItem]

--- a/api/routes/v1/search_index.py
+++ b/api/routes/v1/search_index.py
@@ -20,12 +20,13 @@ async def post_search_index(
     Returns:
         SearchIndexResponse: A dictionary containing the current status.
     """
-    results = request.app.state.embed.search_index_multi(
+    search_results = request.app.state.embed.search_index_multi(
         query=[
             payload.industry_descr or "",
             payload.job_title or "",
             payload.job_description or "",
         ]
     )
-    print(f"Results: {results}")
-    return results
+    response = SearchIndexResponse(results=search_results)
+    print(f"Results: {search_results}")
+    return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sic-classification-vector-store"
-version = "0.1.0"
+version = "0.1.1"
 description = "Generic interface for a vector store used for SIC classification"
 authors = [
     {name = "Steve Gibbard",email = "steve.gibbard@ons.gov.uk"}


### PR DESCRIPTION
# 📌 Pull Request Template

Add JSON response and tweak default port

## ✨ Summary

The response model for the search-index endpoint is updated to return a JSON structure and default port will be 8088

## 📜 Changes Introduced

Updated Makefile - port change
Updated Model and Route for search_index.py - Tweak pydantic model
 
- [x] Feature implementation (feat:)
- (not required) Updates to tests and/or documentation
- ((not required) Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

Pull the latest release and consult README to run locally.