### PR TITLE
feat(sayt): Load SAYT manager into app lifespan and make endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ cython_debug/
 src/sic_classification_vector_store/data/vector_store/*
 
 .DS_Store
+corpus/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "charliermarsh.ruff",
+        "ms-python.black-formatter",
+        "ms-python.isort",
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,14 @@
 {
-    "makefile.configureOnOpen": false
+    "[python]": {
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+        },
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "isort.args": [
+        "--profile",
+        "black"
+    ],
+    "makefile.configureOnOpen": false,
 }

--- a/Makefile
+++ b/Makefile
@@ -45,15 +45,15 @@ black: ## Run black
 
 .PHONY: unit-tests
 unit-tests: ## Run the example unit tests
-	poetry run pytest --ignore=cicd -m utils --cov=utils --cov-report=term-missing --cov-fail-under=80 --cov-config=.coveragerc
+	poetry run pytest --ignore=cicd -m utils --cov=sic_classification_vector_store --cov-report=term-missing --cov-fail-under=80 --cov-config=pyproject.toml
 
 .PHONY: api-tests
 api-tests: ## Run the example API tests
-	poetry run pytest --ignore=cicd -m api --cov=api --cov-report=term-missing --cov-fail-under=80 --cov-config=.coveragerc
+	poetry run pytest --ignore=cicd -m api --cov=sic_classification_vector_store --cov-report=term-missing --cov-fail-under=80 --cov-config=pyproject.toml
 
 .PHONY: all-tests
 all-tests:
-	poetry run pytest --ignore=cicd --cov=. --cov-report=term-missing --cov-fail-under=80 --cov-config=.coveragerc
+	poetry run pytest --ignore=cicd --cov=sic_classification_vector_store --cov-report=term-missing --cov-fail-under=80 --cov-config=pyproject.toml
 
 .PHONY: install	
 install: ## Install the dependencies

--- a/poetry.lock
+++ b/poetry.lock
@@ -934,30 +934,36 @@ files = [
 
 [[package]]
 name = "fastapi"
-version = "0.115.14"
+version = "0.136.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.115.14-py3-none-any.whl", hash = "sha256:6c0c8bf9420bd58f565e585036d971872472b4f7d3f6c73b698e10cffdefb3ca"},
-    {file = "fastapi-0.115.14.tar.gz", hash = "sha256:b1de15cdc1c499a4da47914db35d0e4ef8f1ce62b624e94e0e5824421df99739"},
+    {file = "fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f"},
+    {file = "fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f"},
 ]
 
 [package.dependencies]
+annotated-doc = ">=0.0.2"
 email-validator = {version = ">=2.0.0", optional = true, markers = "extra == \"standard\""}
-fastapi-cli = {version = ">=0.0.5", extras = ["standard"], optional = true, markers = "extra == \"standard\""}
-httpx = {version = ">=0.23.0", optional = true, markers = "extra == \"standard\""}
+fastapi-cli = {version = ">=0.0.8", extras = ["standard"], optional = true, markers = "extra == \"standard\""}
+fastar = {version = ">=0.9.0", optional = true, markers = "extra == \"standard\""}
+httpx = {version = ">=0.23.0,<1.0.0", optional = true, markers = "extra == \"standard\""}
 jinja2 = {version = ">=3.1.5", optional = true, markers = "extra == \"standard\""}
-pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
+pydantic = ">=2.9.0"
+pydantic-extra-types = {version = ">=2.0.0", optional = true, markers = "extra == \"standard\""}
+pydantic-settings = {version = ">=2.0.0", optional = true, markers = "extra == \"standard\""}
 python-multipart = {version = ">=0.0.18", optional = true, markers = "extra == \"standard\""}
-starlette = ">=0.40.0,<0.47.0"
+starlette = ">=0.46.0"
 typing-extensions = ">=4.8.0"
+typing-inspection = ">=0.4.2"
 uvicorn = {version = ">=0.12.0", extras = ["standard"], optional = true, markers = "extra == \"standard\""}
 
 [package.extras]
-all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
-standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "fastar (>=0.9.0)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0,<1.0.0)", "jinja2 (>=3.1.5)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
 name = "fastapi-cli"
@@ -2300,6 +2306,18 @@ files = [
     {file = "jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016"},
     {file = "jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a"},
     {file = "jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e"},
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+description = "Lightweight pipelining with Python functions"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713"},
+    {file = "joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3"},
 ]
 
 [[package]]
@@ -4301,6 +4319,56 @@ files = [
 typing-extensions = ">=4.14.1"
 
 [[package]]
+name = "pydantic-extra-types"
+version = "2.11.1"
+description = "Extra Pydantic types."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1"},
+    {file = "pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049"},
+]
+
+[package.dependencies]
+pydantic = ">=2.5.2"
+typing-extensions = "*"
+
+[package.extras]
+all = ["cron-converter (>=1.2.2)", "pendulum (>=3.0.0,<4.0.0)", "phonenumbers (>=8,<10)", "pycountry (>=23)", "pymongo (>=4.0.0,<5.0.0)", "python-ulid (>=1,<2) ; python_version < \"3.9\"", "python-ulid (>=1,<4) ; python_version >= \"3.9\"", "pytz (>=2024.1)", "semver (>=3.0.2)", "semver (>=3.0.2,<3.1.0)", "tzdata (>=2024.1)", "uuid-utils (>=0.6.0) ; python_version < \"3.14\""]
+cron = ["cron-converter (>=1.2.2)"]
+pendulum = ["pendulum (>=3.0.0,<4.0.0)"]
+phonenumbers = ["phonenumbers (>=8,<10)"]
+pycountry = ["pycountry (>=23)"]
+python-ulid = ["python-ulid (>=1,<2) ; python_version < \"3.9\"", "python-ulid (>=1,<4) ; python_version >= \"3.9\""]
+semver = ["semver (>=3.0.2)"]
+uuid-utils = ["uuid-utils (>=0.6.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de"},
+    {file = "pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+typing-inspection = ">=0.4.0"
+
+[package.extras]
+aws-secrets-manager = ["boto3 (>=1.35.0)", "types-boto3[secretsmanager]"]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -5083,6 +5151,147 @@ testingfree = ["huggingface-hub (>=0.12.1)", "hypothesis (>=6.70.2)", "pytest (>
 torch = ["packaging", "safetensors[numpy]", "torch (>=1.10)"]
 
 [[package]]
+name = "scikit-learn"
+version = "1.8.0"
+description = "A set of python modules for machine learning and data mining"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+files = [
+    {file = "scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da"},
+    {file = "scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1"},
+    {file = "scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e30adb87f0cc81c7690a84f7932dd66be5bac57cfe16b91cb9151683a4a2d3b"},
+    {file = "scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ada8121bcb4dac28d930febc791a69f7cb1673c8495e5eee274190b73a4559c1"},
+    {file = "scikit_learn-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:c57b1b610bd1f40ba43970e11ce62821c2e6569e4d74023db19c6b26f246cb3b"},
+    {file = "scikit_learn-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:2838551e011a64e3053ad7618dda9310175f7515f1742fa2d756f7c874c05961"},
+    {file = "scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e"},
+    {file = "scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76"},
+    {file = "scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4"},
+    {file = "scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a"},
+    {file = "scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809"},
+    {file = "scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb"},
+    {file = "scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a"},
+    {file = "scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e"},
+    {file = "scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57"},
+    {file = "scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e"},
+    {file = "scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271"},
+    {file = "scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3"},
+    {file = "scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735"},
+    {file = "scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd"},
+    {file = "scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e"},
+    {file = "scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb"},
+    {file = "scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702"},
+    {file = "scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde"},
+    {file = "scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3"},
+    {file = "scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7"},
+    {file = "scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6"},
+    {file = "scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4"},
+    {file = "scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6"},
+    {file = "scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242"},
+    {file = "scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7"},
+    {file = "scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9"},
+    {file = "scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f"},
+    {file = "scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9"},
+    {file = "scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2"},
+    {file = "scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c"},
+    {file = "scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd"},
+]
+
+[package.dependencies]
+joblib = ">=1.3.0"
+numpy = ">=1.24.1"
+scipy = ">=1.10.0"
+threadpoolctl = ">=3.2.0"
+
+[package.extras]
+benchmark = ["matplotlib (>=3.6.1)", "memory_profiler (>=0.57.0)", "pandas (>=1.5.0)"]
+build = ["cython (>=3.1.2)", "meson-python (>=0.17.1)", "numpy (>=1.24.1)", "scipy (>=1.10.0)"]
+docs = ["Pillow (>=10.1.0)", "matplotlib (>=3.6.1)", "memory_profiler (>=0.57.0)", "numpydoc (>=1.2.0)", "pandas (>=1.5.0)", "plotly (>=5.18.0)", "polars (>=0.20.30)", "pooch (>=1.8.0)", "pydata-sphinx-theme (>=0.15.3)", "scikit-image (>=0.22.0)", "seaborn (>=0.13.0)", "sphinx (>=7.3.7)", "sphinx-copybutton (>=0.5.2)", "sphinx-design (>=0.6.0)", "sphinx-gallery (>=0.17.1)", "sphinx-prompt (>=1.4.0)", "sphinx-remove-toctrees (>=1.0.0.post1)", "sphinxcontrib-sass (>=0.3.4)", "sphinxext-opengraph (>=0.9.1)", "towncrier (>=24.8.0)"]
+examples = ["matplotlib (>=3.6.1)", "pandas (>=1.5.0)", "plotly (>=5.18.0)", "pooch (>=1.8.0)", "scikit-image (>=0.22.0)", "seaborn (>=0.13.0)"]
+install = ["joblib (>=1.3.0)", "numpy (>=1.24.1)", "scipy (>=1.10.0)", "threadpoolctl (>=3.2.0)"]
+maintenance = ["conda-lock (==3.0.1)"]
+tests = ["matplotlib (>=3.6.1)", "mypy (>=1.15)", "numpydoc (>=1.2.0)", "pandas (>=1.5.0)", "polars (>=0.20.30)", "pooch (>=1.8.0)", "pyamg (>=5.0.0)", "pyarrow (>=12.0.0)", "pytest (>=7.1.2)", "pytest-cov (>=2.9.0)", "ruff (>=0.11.7)"]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+description = "Fundamental algorithms for scientific computing in Python"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+files = [
+    {file = "scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec"},
+    {file = "scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696"},
+    {file = "scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee"},
+    {file = "scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd"},
+    {file = "scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c"},
+    {file = "scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4"},
+    {file = "scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444"},
+    {file = "scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082"},
+    {file = "scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff"},
+    {file = "scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d"},
+    {file = "scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8"},
+    {file = "scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76"},
+    {file = "scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086"},
+    {file = "scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b"},
+    {file = "scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21"},
+    {file = "scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458"},
+    {file = "scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb"},
+    {file = "scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea"},
+    {file = "scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87"},
+    {file = "scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3"},
+    {file = "scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c"},
+    {file = "scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f"},
+    {file = "scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d"},
+    {file = "scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b"},
+    {file = "scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6"},
+    {file = "scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464"},
+    {file = "scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950"},
+    {file = "scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369"},
+    {file = "scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448"},
+    {file = "scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87"},
+    {file = "scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a"},
+    {file = "scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0"},
+    {file = "scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce"},
+    {file = "scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6"},
+    {file = "scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e"},
+    {file = "scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475"},
+    {file = "scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50"},
+    {file = "scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca"},
+    {file = "scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c"},
+    {file = "scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49"},
+    {file = "scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717"},
+    {file = "scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9"},
+    {file = "scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b"},
+    {file = "scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866"},
+    {file = "scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350"},
+    {file = "scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118"},
+    {file = "scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068"},
+    {file = "scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118"},
+    {file = "scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19"},
+    {file = "scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293"},
+    {file = "scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6"},
+    {file = "scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1"},
+    {file = "scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39"},
+    {file = "scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca"},
+    {file = "scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad"},
+    {file = "scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a"},
+    {file = "scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4"},
+    {file = "scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2"},
+    {file = "scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484"},
+    {file = "scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21"},
+    {file = "scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0"},
+]
+
+[package.dependencies]
+numpy = ">=1.26.4,<2.7"
+
+[package.extras]
+dev = ["click (<8.3.0)", "cython-lint (>=0.12.2)", "mypy (==1.10.0)", "pycodestyle", "ruff (>=0.12.0)", "spin", "types-psutil", "typing_extensions"]
+doc = ["intersphinx_registry", "jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.19.1)", "jupytext", "linkify-it-py", "matplotlib (>=3.5)", "myst-nb (>=1.2.0)", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0,<8.2.0)", "sphinx-copybutton", "sphinx-design (>=0.4.0)", "tabulate"]
+test = ["Cython", "array-api-strict (>=2.3.1)", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja ; sys_platform != \"emscripten\"", "pooch", "pytest (>=8.0.0)", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+
+[[package]]
 name = "sentry-sdk"
 version = "2.58.0"
 description = "Python client for Sentry (https://sentry.io)"
@@ -5224,10 +5433,10 @@ resolved_reference = "3487e260c58072337818b314d74dce8ba24750b3"
 
 [[package]]
 name = "sic-classification-utils"
-version = "0.1.10"
+version = "0.1.11"
 description = "Utility functions used for SIC classification"
 optional = false
-python-versions = "^3.12"
+python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = []
 develop = false
@@ -5244,14 +5453,16 @@ numpy = "^2.3.0"
 openpyxl = "^3.1.5"
 pandas = "^2.3.0"
 pydantic = "^2.11.1"
+scikit-learn = "^1.3.0"
+scipy = "^1.15.0"
 sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.3"}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.8"}
 
 [package.source]
 type = "git"
 url = "https://github.com/ONSdigital/sic-classification-utils"
-reference = "v0.1.10"
-resolved_reference = "dfaf37842e58df9a9ec2ca6f528a086619f6719f"
+reference = "v0.1.11"
+resolved_reference = "ec0d88314c0c0a803b598c889a77c5b88f9fcd93"
 
 [[package]]
 name = "six"
@@ -5464,6 +5675,18 @@ files = [
 [package.extras]
 doc = ["reno", "sphinx"]
 test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+description = "threadpoolctl"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb"},
+    {file = "threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e"},
+]
 
 [[package]]
 name = "tiktoken"
@@ -6660,4 +6883,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "c22194a921efc094c877c7a1bea193d7c48b051518daa1d08a95094501d846eb"
+content-hash = "d771f2e23ab1441d03cb63c0a192bd48265d8ab7038a8e00970a0742f1b190e0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ packages = [{ include = "sic_classification_vector_store", from = "src" }]
 
 [tool.poetry.dependencies]
 python = "^3.12"
-fastapi = "^0.115.9"
+fastapi = "^0.136.1"
 uvicorn = "^0.34.0"
 pydantic = "^2.10.6"
 pytest-asyncio = "^1.3.0"
-sic-classification-utils = { git = "https://github.com/ONSdigital/sic-classification-utils", tag = "v0.1.10" }
+sic-classification-utils = { git = "https://github.com/ONSdigital/sic-classification-utils", tag = "v0.1.11" }
 survey-assist-utils = { git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.8" }
 
 [tool.isort]
@@ -75,6 +75,12 @@ convention = "google"
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.coverage.run]
+source = ["sic_classification_vector_store"]
+
+[tool.coverage.report]
+omit = ["tests/*"]
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/src/sic_classification_vector_store/api/deps.py
+++ b/src/sic_classification_vector_store/api/deps.py
@@ -1,0 +1,21 @@
+"""Shared FastAPI dependencies for SIC vector-store routes."""
+
+from typing import cast
+
+from fastapi import Request
+
+from sic_classification_vector_store.utils.sayt import SaytManager
+from sic_classification_vector_store.utils.vector_store import (
+    VectorStoreManager,
+    vector_store_manager,
+)
+
+
+def get_vector_store() -> VectorStoreManager:
+    """Get the shared vector-store manager."""
+    return vector_store_manager
+
+
+def get_sayt_manager(request: Request) -> SaytManager:
+    """Get the warmed SAYT manager from FastAPI request state."""
+    return cast(SaytManager, request.state.sayt_manager)

--- a/src/sic_classification_vector_store/api/main.py
+++ b/src/sic_classification_vector_store/api/main.py
@@ -24,7 +24,7 @@ logger: SurveyAssistLogger = get_logger(__name__)
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(_app: FastAPI):
     """FastAPI lifespan handler to load vector store in background."""
     sayt_manager: SaytManager = create_sayt_manager()
 

--- a/src/sic_classification_vector_store/api/main.py
+++ b/src/sic_classification_vector_store/api/main.py
@@ -17,7 +17,7 @@ from sic_classification_vector_store.api.routes.v1.search_index import (
     router as search_index_router,
 )
 from sic_classification_vector_store.api.routes.v1.status import router as status_router
-from sic_classification_vector_store.utils.sayt import SaytManager, create_sayt_manager
+from sic_classification_vector_store.utils.sayt import SaytManager
 from sic_classification_vector_store.utils.vector_store import vector_store_manager
 
 logger: SurveyAssistLogger = get_logger(__name__)
@@ -26,7 +26,7 @@ logger: SurveyAssistLogger = get_logger(__name__)
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     """FastAPI lifespan handler to load vector store in background."""
-    sayt_manager: SaytManager = create_sayt_manager()
+    sayt_manager: SaytManager = SaytManager()
 
     def background_load():
         try:

--- a/src/sic_classification_vector_store/api/main.py
+++ b/src/sic_classification_vector_store/api/main.py
@@ -10,19 +10,23 @@ from threading import Thread
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from survey_assist_utils.logging import get_logger
+from survey_assist_utils.logging.logging_utils import SurveyAssistLogger
 
+from sic_classification_vector_store.api.routes.v1.sayt import router as sayt_router
 from sic_classification_vector_store.api.routes.v1.search_index import (
     router as search_index_router,
 )
 from sic_classification_vector_store.api.routes.v1.status import router as status_router
+from sic_classification_vector_store.utils.sayt import SaytManager, create_sayt_manager
 from sic_classification_vector_store.utils.vector_store import vector_store_manager
 
-logger = get_logger(__name__)
+logger: SurveyAssistLogger = get_logger(__name__)
 
 
 @asynccontextmanager
-async def lifespan(_app: FastAPI):
+async def lifespan(app: FastAPI):
     """FastAPI lifespan handler to load vector store in background."""
+    sayt_manager: SaytManager = create_sayt_manager()
 
     def background_load():
         try:
@@ -35,13 +39,27 @@ async def lifespan(_app: FastAPI):
             logger.info("Vector store is ready")
         except Exception as e:  # pylint: disable=broad-exception-caught
             vector_store_manager.load_error = str(e)
-            logger.error(f"Error loading vector store: {e}", exc_info=True)
+            logger.error("Error loading vector store", error_msg=str(e), exc_info=True)
             vector_store_manager.ready_event.set()  # Set event even on error to prevent hanging
+
+    def background_load_sayt():
+        try:
+            logger.info("Loading the SIC SAYT suggester")
+            sayt_manager.load()
+            sayt_manager.ready_event.set()
+            logger.info("SIC SAYT suggester is ready")
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            sayt_manager.load_error = str(e)
+            logger.error(
+                "Error loading SIC SAYT suggester", error_msg=str(e), exc_info=True
+            )
+            sayt_manager.ready_event.set()
 
     # Start loading in a separate thread
     Thread(target=background_load, daemon=True).start()
+    Thread(target=background_load_sayt, daemon=True).start()
 
-    yield  # Let the app run
+    yield {"sayt_manager": sayt_manager}
 
     logger.info("Shutting down...")
 
@@ -67,6 +85,7 @@ async def generic_error_handler(_request: Request, exc: Exception) -> JSONRespon
 # Include versioned routes
 app.include_router(status_router, prefix="/v1/sic-vector-store")
 app.include_router(search_index_router, prefix="/v1/sic-vector-store")
+app.include_router(sayt_router, prefix="/v1/sic-vector-store")
 
 
 @app.get("/")

--- a/src/sic_classification_vector_store/api/models/sayt.py
+++ b/src/sic_classification_vector_store/api/models/sayt.py
@@ -1,0 +1,18 @@
+"""Models for the SIC search-as-you-type endpoint."""
+
+from pydantic import BaseModel, Field
+
+
+class SICSaytResponse(BaseModel):
+    """Response model for SIC search-as-you-type suggestions."""
+
+    suggestions: list[str] = Field(default_factory=list)
+
+
+SIC_SAYT_RESPONSE_EXAMPLE: dict[str, list[str]] = SICSaytResponse(
+    suggestions=[
+        "Street lighting installation",
+        "Installation and maintenance of refrigeration",
+        "Insulating activities",
+    ]
+).model_dump()

--- a/src/sic_classification_vector_store/api/models/status.py
+++ b/src/sic_classification_vector_store/api/models/status.py
@@ -4,7 +4,17 @@ The models in this module are used to represent the response
 returned by the API.
 """
 
+from enum import StrEnum
+
 from pydantic import BaseModel
+
+
+class RuntimeStatus(StrEnum):
+    """Lifecycle status for a runtime-managed component."""
+
+    LOADING = "loading"
+    READY = "ready"
+    ERROR = "error"
 
 
 class FileSource(BaseModel):
@@ -30,10 +40,12 @@ class StatusResponse(BaseModel):
         sic_condensed_source (FileSource): The condensed SIC reference file.
         matches (int): The number of nearest matches initialised in the vector store.
         index_size (int): The number of embedded entries in the vector store.
-        status (str): The status of the vector store.
+        vector_store_status (str): The status of the vector store.
+        sayt_status (str): The status of the SIC search-as-you-type suggester.
     """
 
-    status: str
+    vector_store_status: RuntimeStatus
+    sayt_status: RuntimeStatus
     embedding_model_name: str
     db_dir: str
     sic_index_source: FileSource

--- a/src/sic_classification_vector_store/api/routes/v1/sayt.py
+++ b/src/sic_classification_vector_store/api/routes/v1/sayt.py
@@ -1,0 +1,64 @@
+"""Module that provides the SIC search-as-you-type endpoint."""
+
+import time
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from survey_assist_utils.logging import get_logger
+from survey_assist_utils.logging.logging_utils import SurveyAssistLogger
+
+from sic_classification_vector_store.api.models.sayt import (
+    SIC_SAYT_RESPONSE_EXAMPLE,
+    SICSaytResponse,
+)
+from sic_classification_vector_store.utils.sayt import SaytManager
+
+router = APIRouter(tags=["SIC SAYT"])
+logger: SurveyAssistLogger = get_logger(__name__)
+
+
+def get_sayt_manager(request: Request) -> SaytManager:
+    """Get the warmed SAYT manager from FastAPI request state."""
+    return request.state.sayt_manager
+
+
+@router.get(
+    "/sayt",
+    response_model=SICSaytResponse,
+    responses={
+        200: {
+            "description": "SIC search-as-you-type suggestions",
+            "content": {"application/json": {"example": SIC_SAYT_RESPONSE_EXAMPLE}},
+        }
+    },
+)
+async def get_sic_sayt(
+    description: str,
+    sayt_manager: Annotated[SaytManager, Depends(get_sayt_manager)],
+    num_suggestions: Annotated[int | None, Query(ge=1, le=100)] = None,
+) -> SICSaytResponse:
+    """Return SIC description suggestions as the user types."""
+    start_time = time.perf_counter()
+
+    if not description:
+        raise HTTPException(status_code=400, detail="Description cannot be empty")
+
+    try:
+        suggestions = sayt_manager.suggest(description, num_suggestions)
+    except RuntimeError as e:
+        logger.error("SIC SAYT service unavailable", error=str(e))
+        raise HTTPException(status_code=503, detail=str(e)) from e
+    except Exception as e:
+        logger.error("Error retrieving SIC SAYT suggestions", error=str(e))
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error retrieving SIC SAYT suggestions: {e!s}",
+        ) from e
+
+    duration_ms = int((time.perf_counter() - start_time) * 1000)
+    logger.info(
+        "SIC SAYT response sent",
+        suggestion_count=str(len(suggestions)),
+        duration_ms=str(duration_ms),
+    )
+    return SICSaytResponse(suggestions=suggestions)

--- a/src/sic_classification_vector_store/api/routes/v1/sayt.py
+++ b/src/sic_classification_vector_store/api/routes/v1/sayt.py
@@ -3,10 +3,11 @@
 import time
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 from survey_assist_utils.logging import get_logger
 from survey_assist_utils.logging.logging_utils import SurveyAssistLogger
 
+from sic_classification_vector_store.api.deps import get_sayt_manager
 from sic_classification_vector_store.api.models.sayt import (
     SIC_SAYT_RESPONSE_EXAMPLE,
     SICSaytResponse,
@@ -15,11 +16,6 @@ from sic_classification_vector_store.utils.sayt import SaytManager
 
 router = APIRouter(tags=["SIC SAYT"])
 logger: SurveyAssistLogger = get_logger(__name__)
-
-
-def get_sayt_manager(request: Request) -> SaytManager:
-    """Get the warmed SAYT manager from FastAPI request state."""
-    return request.state.sayt_manager
 
 
 @router.get(

--- a/src/sic_classification_vector_store/api/routes/v1/status.py
+++ b/src/sic_classification_vector_store/api/routes/v1/status.py
@@ -9,39 +9,44 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends
 
-from sic_classification_vector_store.api.models.status import FileSource, StatusResponse
-from sic_classification_vector_store.utils.common import safe_int
-from sic_classification_vector_store.utils.vector_store import (
-    VectorStoreManager,
-    vector_store_manager,
+from sic_classification_vector_store.api.deps import get_sayt_manager, get_vector_store
+from sic_classification_vector_store.api.models.status import (
+    FileSource,
+    RuntimeStatus,
+    StatusResponse,
 )
+from sic_classification_vector_store.utils.common import safe_int
+from sic_classification_vector_store.utils.sayt import SaytManager
+from sic_classification_vector_store.utils.vector_store import VectorStoreManager
 
 router = APIRouter(tags=["Status"])
-
-
-def get_vector_store():
-    """Get a vector store instance.
-
-    Returns:
-        VectorStoreManager: A vector store manager instance.
-    """
-    return vector_store_manager
 
 
 @router.get("/status", response_model=StatusResponse)
 async def get_status(
     vector_store: Annotated[VectorStoreManager, Depends(get_vector_store)],
+    sayt_manager: Annotated[SaytManager, Depends(get_sayt_manager)],
 ) -> StatusResponse:
     """Get the current status of the vector store.
 
     Args:
         vector_store: Vector store manager instance
+        sayt_manager: SIC SAYT manager instance
 
     Returns:
         StatusResponse: A dictionary containing the current status.
     """
-    status_resp = StatusResponse(
-        status=_resolve_status(vector_store),
+    return StatusResponse(
+        vector_store_status=_resolve_manager_status(
+            is_ready=vector_store.ready_event.is_set(),
+            loaded_value=vector_store.embed,
+            load_error=vector_store.load_error,
+        ),
+        sayt_status=_resolve_manager_status(
+            is_ready=sayt_manager.ready_event.is_set(),
+            loaded_value=sayt_manager.suggester,
+            load_error=sayt_manager.load_error,
+        ),
         embedding_model_name=str(vector_store.status.get("embedding_model_name", "")),
         db_dir=str(vector_store.status.get("db_dir", "")),
         sic_index_source=_resolve_file_source(vector_store.status.get("sic_index", "")),
@@ -54,21 +59,22 @@ async def get_status(
         matches=safe_int(vector_store.status.get("matches", 0)),
         index_size=safe_int(vector_store.status.get("index_size", 0)),
     )
-    return status_resp
 
 
-def _resolve_status(vector_store: VectorStoreManager) -> str:
-    """Resolve the current vector store lifecycle status."""
-    if vector_store.load_error is not None:
-        return "error"
+def _resolve_manager_status(
+    *, is_ready: bool, loaded_value: object | None, load_error: str | None
+) -> RuntimeStatus:
+    """Resolve the shared lifecycle status for a managed component."""
+    if load_error is not None:
+        return RuntimeStatus.ERROR
 
-    if vector_store.ready_event.is_set() and vector_store.embed is not None:
-        return "ready"
+    if is_ready and loaded_value is not None:
+        return RuntimeStatus.READY
 
-    return "loading"
+    return RuntimeStatus.LOADING
 
 
-def _resolve_file_source(vector_store_status: tuple[str, ...] | str) -> FileSource:
+def _resolve_file_source(vector_store_status: object) -> FileSource:
     """Resolve a file source from the vector store status."""
     raw_status = vector_store_status if isinstance(vector_store_status, str) else None
 

--- a/src/sic_classification_vector_store/utils/sayt.py
+++ b/src/sic_classification_vector_store/utils/sayt.py
@@ -27,7 +27,8 @@ def resolve_sayt_data_path() -> str:
         return str(resolved_path)
     except (ImportError, OSError) as e:
         fallback_path: str = (
-            "/usr/local/lib/python3.12/site-packages/industrial_classification/data/example_sic_lookup_data.csv"
+            "/usr/local/lib/python3.12/site-packages/industrial_classification/"
+            "data/example_sic_lookup_data.csv"
         )
         logger.warning(
             "Could not resolve packaged SIC SAYT data, using fallback",

--- a/src/sic_classification_vector_store/utils/sayt.py
+++ b/src/sic_classification_vector_store/utils/sayt.py
@@ -4,7 +4,6 @@ import os
 import time
 from importlib import resources
 from importlib.resources.abc import Traversable
-from pathlib import Path
 from threading import Event
 
 from industrial_classification_utils.sayt import SAYTSuggester
@@ -41,18 +40,18 @@ def resolve_sayt_data_path() -> str:
 class SaytManager:
     """Manage lifecycle and access to the SIC SAYT suggester."""
 
-    def __init__(self, data_path: str | None = None) -> None:
+    def __init__(self, data_path: str | os.PathLike | None = None) -> None:
         """Initialise the SAYT manager."""
         self.ready_event = Event()
         self.suggester: SAYTSuggester | None = None
         self.load_error: str | None = None
-        self.data_path: str = data_path or ""
+        self.data_path: str = (
+            resolve_sayt_data_path() if data_path is None else str(data_path)
+        )
 
     def load(self) -> None:
         """Build the underlying SAYT suggester."""
         self.load_error = None
-        if not self.data_path:
-            self.data_path = resolve_sayt_data_path()
 
         start_time = time.perf_counter()
         logger.info("Loading SIC SAYT suggester", data_path=self.data_path)
@@ -82,10 +81,3 @@ class SaytManager:
             raise RuntimeError("SAYT suggester not loaded")
 
         return self.suggester.suggest(description, num_suggestions)
-
-
-def create_sayt_manager(data_path: str | Path | None = None) -> SaytManager:
-    """Create a SAYT manager with optional preconfigured data path."""
-    resolved_data_path: str | None = None if data_path is None else str(data_path)
-
-    return SaytManager(data_path=resolved_data_path)

--- a/src/sic_classification_vector_store/utils/sayt.py
+++ b/src/sic_classification_vector_store/utils/sayt.py
@@ -1,0 +1,90 @@
+"""Utilities for the SIC search-as-you-type suggester."""
+
+import os
+import time
+from importlib import resources
+from importlib.resources.abc import Traversable
+from pathlib import Path
+from threading import Event
+
+from industrial_classification_utils.sayt import SAYTSuggester
+from survey_assist_utils.logging import get_logger
+from survey_assist_utils.logging.logging_utils import SurveyAssistLogger
+
+logger: SurveyAssistLogger = get_logger(__name__)
+
+
+def resolve_sayt_data_path() -> str:
+    """Resolve the CSV path used to build the SIC SAYT suggester."""
+    env_path = os.getenv("SIC_LOOKUP_DATA_PATH")
+    if env_path and env_path.strip():
+        return env_path.strip()
+
+    try:
+        data_dir: Traversable = resources.files("industrial_classification.data")
+        resolved_path: Traversable = data_dir / "example_sic_lookup_data.csv"
+        logger.info("Using packaged SIC SAYT data", data_path=str(resolved_path))
+        return str(resolved_path)
+    except (ImportError, OSError) as e:
+        fallback_path: str = (
+            "/usr/local/lib/python3.12/site-packages/industrial_classification/data/example_sic_lookup_data.csv"
+        )
+        logger.warning(
+            "Could not resolve packaged SIC SAYT data, using fallback",
+            data_path=fallback_path,
+            error=str(e),
+        )
+        return fallback_path
+
+
+class SaytManager:
+    """Manage lifecycle and access to the SIC SAYT suggester."""
+
+    def __init__(self, data_path: str | None = None) -> None:
+        """Initialise the SAYT manager."""
+        self.ready_event = Event()
+        self.suggester: SAYTSuggester | None = None
+        self.load_error: str | None = None
+        self.data_path: str = data_path or ""
+
+    def load(self) -> None:
+        """Build the underlying SAYT suggester."""
+        self.load_error = None
+        if not self.data_path:
+            self.data_path = resolve_sayt_data_path()
+
+        start_time = time.perf_counter()
+        logger.info("Loading SIC SAYT suggester", data_path=self.data_path)
+        self.suggester = SAYTSuggester.from_csv(
+            self.data_path,
+            search_text_col="description",
+            display_text_col="description",
+        )
+        duration_ms = int((time.perf_counter() - start_time) * 1000)
+        logger.info(
+            "Loaded SIC SAYT suggester",
+            data_path=self.data_path,
+            duration_ms=str(duration_ms),
+        )
+
+    def suggest(
+        self, description: str | None, num_suggestions: int | None = None
+    ) -> list[str]:
+        """Return suggestions from the warmed SAYT suggester."""
+        if self.load_error is not None:
+            raise RuntimeError(f"SAYT suggester failed to load: {self.load_error}")
+
+        if not self.ready_event.is_set():
+            raise RuntimeError("SAYT suggester is not ready")
+
+        if self.suggester is None:
+            raise RuntimeError("SAYT suggester not loaded")
+
+        return self.suggester.suggest(description, num_suggestions)
+
+
+def create_sayt_manager(data_path: str | Path | None = None) -> SaytManager:
+    """Create a SAYT manager with optional preconfigured data path."""
+    resolved_data_path: str | None = None if data_path is None else str(data_path)
+
+    return SaytManager(data_path=resolved_data_path)

--- a/src/sic_classification_vector_store/utils/sayt.py
+++ b/src/sic_classification_vector_store/utils/sayt.py
@@ -2,8 +2,9 @@
 
 import os
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from importlib import resources
-from importlib.resources.abc import Traversable
 from threading import Event
 
 from industrial_classification_utils.sayt import SAYTSuggester
@@ -11,30 +12,6 @@ from survey_assist_utils.logging import get_logger
 from survey_assist_utils.logging.logging_utils import SurveyAssistLogger
 
 logger: SurveyAssistLogger = get_logger(__name__)
-
-
-def resolve_sayt_data_path() -> str:
-    """Resolve the CSV path used to build the SIC SAYT suggester."""
-    env_path = os.getenv("SIC_LOOKUP_DATA_PATH")
-    if env_path and env_path.strip():
-        return env_path.strip()
-
-    try:
-        data_dir: Traversable = resources.files("industrial_classification.data")
-        resolved_path: Traversable = data_dir / "example_sic_lookup_data.csv"
-        logger.info("Using packaged SIC SAYT data", data_path=str(resolved_path))
-        return str(resolved_path)
-    except (ImportError, OSError) as e:
-        fallback_path: str = (
-            "/usr/local/lib/python3.12/site-packages/industrial_classification/"
-            "data/example_sic_lookup_data.csv"
-        )
-        logger.warning(
-            "Could not resolve packaged SIC SAYT data, using fallback",
-            data_path=fallback_path,
-            error=str(e),
-        )
-        return fallback_path
 
 
 class SaytManager:
@@ -45,25 +22,26 @@ class SaytManager:
         self.ready_event = Event()
         self.suggester: SAYTSuggester | None = None
         self.load_error: str | None = None
-        self.data_path: str = (
-            resolve_sayt_data_path() if data_path is None else str(data_path)
-        )
+        self.data_path: str | None = None if data_path is None else str(data_path)
 
     def load(self) -> None:
         """Build the underlying SAYT suggester."""
         self.load_error = None
 
         start_time = time.perf_counter()
-        logger.info("Loading SIC SAYT suggester", data_path=self.data_path)
-        self.suggester = SAYTSuggester.from_csv(
-            self.data_path,
-            search_text_col="description",
-            display_text_col="description",
-        )
+        with _resolve_sayt_data_file(self.data_path) as resolved_path:
+            active_data_path = str(resolved_path)
+            logger.info("Loading SIC SAYT suggester", data_path=active_data_path)
+            self.suggester = SAYTSuggester.from_csv(
+                resolved_path,
+                search_text_col="description",
+                display_text_col="description",
+            )
+
         duration_ms = int((time.perf_counter() - start_time) * 1000)
         logger.info(
             "Loaded SIC SAYT suggester",
-            data_path=self.data_path,
+            data_path=active_data_path,
             duration_ms=str(duration_ms),
         )
 
@@ -81,3 +59,43 @@ class SaytManager:
             raise RuntimeError("SAYT suggester not loaded")
 
         return self.suggester.suggest(description, num_suggestions)
+
+
+@contextmanager
+def _resolve_sayt_data_file(
+    data_path: str | os.PathLike | None,
+) -> Iterator[str | os.PathLike]:
+    """Yield a concrete CSV path for loading the SIC SAYT suggester."""
+    if data_path is not None:
+        yield data_path
+        return
+
+    env_path = os.getenv("SIC_LOOKUP_DATA_PATH")
+    if env_path and env_path.strip():
+        yield env_path.strip()
+        return
+
+    try:
+        packaged_data = (
+            resources.files("industrial_classification.data")
+            / "example_sic_lookup_data.csv"
+        )
+    except (ImportError, OSError) as e:
+        message = (
+            "Could not resolve packaged SIC SAYT data. "
+            "Set SIC_LOOKUP_DATA_PATH to override the CSV path."
+        )
+        logger.warning(message, error=str(e))
+        raise RuntimeError(message) from e
+
+    if not packaged_data.is_file():
+        message = (
+            "Packaged SIC SAYT data not found. "
+            "Set SIC_LOOKUP_DATA_PATH to override the CSV path."
+        )
+        logger.warning(message, data_path=str(packaged_data))
+        raise RuntimeError(message)
+
+    logger.info("Using packaged SIC SAYT data", data_path=str(packaged_data))
+    with resources.as_file(packaged_data) as resolved_path:
+        yield resolved_path

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,6 +25,8 @@ from survey_assist_utils.logging import get_logger
 from sic_classification_vector_store.api.main import (
     app,  # Adjust the import based on your project structure
 )
+from sic_classification_vector_store.api.routes.v1.status import get_sayt_manager
+from sic_classification_vector_store.utils.sayt import SaytManager
 
 logger = get_logger(__name__)
 client = TestClient(app)  # Create a test client for your FastAPI app
@@ -32,7 +34,8 @@ client = TestClient(app)  # Create a test client for your FastAPI app
 MAX_WAIT_TIME = 8 * 60  # 8 minutes in seconds
 POLL_INTERVAL = 10  # Poll every 10 seconds
 STATUS_RESPONSE_KEYS = {
-    "status",
+    "vector_store_status",
+    "sayt_status",
     "embedding_model_name",
     "db_dir",
     "sic_index_source",
@@ -42,6 +45,12 @@ STATUS_RESPONSE_KEYS = {
     "index_size",
 }
 FILE_SOURCE_KEYS = {"package", "file"}
+VALID_RUNTIME_STATUSES = {"loading", "ready", "error"}
+
+
+def _make_loading_sayt_manager() -> SaytManager:
+    """Build an unready SAYT manager for status-endpoint contract tests."""
+    return SaytManager("/resolved/example_sic_lookup_data.csv")
 
 
 def _assert_file_source(file_source: dict[str, str]) -> None:
@@ -73,13 +82,20 @@ def test_get_status_loading():
 
     Assertions:
     - The response status code is HTTPStatus.OK.
-    - The `status` in the response JSON is set to "loading".
+    - The `vector_store_status` in the response JSON is set to "loading".
+    - The `sayt_status` in the response JSON is set to "loading".
     """
-    response = client.get("/v1/sic-vector-store/status")
-    data = response.json()
+    app.dependency_overrides[get_sayt_manager] = _make_loading_sayt_manager
+
+    try:
+        response = client.get("/v1/sic-vector-store/status")
+        data = response.json()
+    finally:
+        app.dependency_overrides.clear()
 
     assert response.status_code == HTTPStatus.OK
-    assert data["status"] == "loading"
+    assert data["vector_store_status"] == "loading"
+    assert data["sayt_status"] == "loading"
     assert set(data) == STATUS_RESPONSE_KEYS
     assert data["embedding_model_name"] is not None
     assert isinstance(data["embedding_model_name"], str)
@@ -99,11 +115,13 @@ def test_status_ready():
 
     This test periodically checks the status endpoint to wait for the vector store
     to be ready. If the status does not become "ready" within 8 minutes, the test fails.
-    Once the status is "ready", it verifies that the returned values are not "unknown" or 0.
+    Once the vector store is ready, it verifies that the core status payload is populated
+    and that SAYT reports a valid component status without blocking core readiness.
 
     Assertions:
     - The response status code is HTTPStatus.OK.
-    - The `status` in the response JSON is "ready".
+    - The `vector_store_status` in the response JSON is "ready".
+    - The `sayt_status` in the response JSON is a valid component status.
     - None of the status fields are "unknown".
     - Numeric fields (`matches`, `index_size`) are greater than 0.
     """
@@ -116,12 +134,16 @@ def test_status_ready():
             assert response.status_code == HTTPStatus.OK
 
             data = response.json()
-            if data["status"] == "error":
-                pytest.fail("The vector store reported an error during startup.")
+            if data["vector_store_status"] == "error":
+                raise AssertionError(
+                    "The vector store reported an error during startup."
+                )
 
-            if data["status"] == "ready":
+            if data["vector_store_status"] == "ready":
                 # Verify that none of the fields are "unknown" or 0
                 assert set(data) == STATUS_RESPONSE_KEYS
+                assert data["sayt_status"] in VALID_RUNTIME_STATUSES
+                assert data["sayt_status"] != "error"
                 assert data["embedding_model_name"] != "unknown"
                 assert data["db_dir"] != "unknown"
                 _assert_file_source(data["sic_index_source"])
@@ -137,7 +159,9 @@ def test_status_ready():
             # Check if the maximum wait time has been exceeded
             elapsed_time = time.time() - start_time
             if elapsed_time > MAX_WAIT_TIME:
-                pytest.fail("The vector store did not become ready within 8 minutes.")
+                raise AssertionError(
+                    "The vector store did not become ready within 8 minutes."
+                )
 
             # Wait before polling again
             time.sleep(POLL_INTERVAL)

--- a/tests/test_sayt_manager.py
+++ b/tests/test_sayt_manager.py
@@ -6,7 +6,6 @@ import pytest
 
 from sic_classification_vector_store.utils.sayt import (
     SaytManager,
-    create_sayt_manager,
     resolve_sayt_data_path,
 )
 
@@ -89,7 +88,7 @@ def test_load_builds_suggester(mocker) -> None:
 
 def test_suggest_requires_ready_manager() -> None:
     """The manager should reject requests until the suggester is ready."""
-    manager = SaytManager()
+    manager = SaytManager("/resolved/example_sic_lookup_data.csv")
 
     try:
         manager.suggest("street")
@@ -101,7 +100,7 @@ def test_suggest_requires_ready_manager() -> None:
 
 def test_suggest_surfaces_load_error() -> None:
     """The manager should surface startup failures before serving suggestions."""
-    manager = SaytManager()
+    manager = SaytManager("/resolved/example_sic_lookup_data.csv")
     manager.load_error = "csv missing"
 
     with pytest.raises(
@@ -112,7 +111,7 @@ def test_suggest_surfaces_load_error() -> None:
 
 def test_suggest_requires_loaded_suggester_when_ready() -> None:
     """The manager should reject requests if readiness is set without a suggester."""
-    manager = SaytManager()
+    manager = SaytManager("/resolved/example_sic_lookup_data.csv")
     manager.ready_event.set()
 
     with pytest.raises(RuntimeError, match="SAYT suggester not loaded"):
@@ -121,7 +120,7 @@ def test_suggest_requires_loaded_suggester_when_ready() -> None:
 
 def test_suggest_uses_loaded_suggester(mocker) -> None:
     """The manager should delegate suggestions to the warmed suggester."""
-    manager = SaytManager()
+    manager = SaytManager("/resolved/example_sic_lookup_data.csv")
     manager.ready_event.set()
     mock_suggester = mocker.Mock()
     mock_suggester.suggest.return_value = ["Street lighting installation"]
@@ -133,8 +132,8 @@ def test_suggest_uses_loaded_suggester(mocker) -> None:
     mock_suggester.suggest.assert_called_once_with("street", 2)
 
 
-def test_create_sayt_manager_normalises_path_objects() -> None:
-    """The manager factory should normalise path-like input."""
-    manager = create_sayt_manager(Path("/resolved/example_sic_lookup_data.csv"))
+def test_sayt_manager_normalises_path_objects() -> None:
+    """The manager should normalise path-like input."""
+    manager = SaytManager(Path("/resolved/example_sic_lookup_data.csv"))
 
     assert manager.data_path == "/resolved/example_sic_lookup_data.csv"

--- a/tests/test_sayt_manager.py
+++ b/tests/test_sayt_manager.py
@@ -123,13 +123,14 @@ def test_suggest_uses_loaded_suggester(mocker) -> None:
     """The manager should delegate suggestions to the warmed suggester."""
     manager = SaytManager()
     manager.ready_event.set()
-    manager.suggester = mocker.Mock()
-    manager.suggester.suggest.return_value = ["Street lighting installation"]
+    mock_suggester = mocker.Mock()
+    mock_suggester.suggest.return_value = ["Street lighting installation"]
+    manager.suggester = mock_suggester
 
     result = manager.suggest("street", 2)
 
     assert result == ["Street lighting installation"]
-    manager.suggester.suggest.assert_called_once_with("street", 2)
+    mock_suggester.suggest.assert_called_once_with("street", 2)
 
 
 def test_create_sayt_manager_normalises_path_objects() -> None:

--- a/tests/test_sayt_manager.py
+++ b/tests/test_sayt_manager.py
@@ -1,74 +1,20 @@
 """Unit tests for the SIC SAYT manager."""
 
+from contextlib import nullcontext
 from pathlib import Path
 
 import pytest
 
-from sic_classification_vector_store.utils.sayt import (
-    SaytManager,
-    resolve_sayt_data_path,
-)
+from sic_classification_vector_store.utils.sayt import SaytManager
 
 pytestmark = pytest.mark.utils
 
 
-def test_resolve_sayt_data_path_prefers_env_var(monkeypatch) -> None:
-    """The resolver should prefer a non-empty environment override."""
+def test_load_uses_env_override_when_configured(mocker, monkeypatch) -> None:
+    """The manager should prefer an environment override when no path is supplied."""
     monkeypatch.setenv("SIC_LOOKUP_DATA_PATH", "  /configured/sayt.csv  ")
-
-    assert resolve_sayt_data_path() == "/configured/sayt.csv"
-
-
-def test_resolve_sayt_data_path_uses_packaged_data_when_available(
-    mocker, monkeypatch
-) -> None:
-    """The resolver should return the packaged CSV path when it is available."""
-    packaged_data_dir = Path("/package/data")
-    monkeypatch.delenv("SIC_LOOKUP_DATA_PATH", raising=False)
-    mocker.patch(
-        "sic_classification_vector_store.utils.sayt.resources.files",
-        return_value=packaged_data_dir,
-    )
-    mock_info = mocker.patch("sic_classification_vector_store.utils.sayt.logger.info")
-
-    assert resolve_sayt_data_path() == "/package/data/example_sic_lookup_data.csv"
-    mock_info.assert_called_once_with(
-        "Using packaged SIC SAYT data",
-        data_path="/package/data/example_sic_lookup_data.csv",
-    )
-
-
-def test_resolve_sayt_data_path_falls_back_when_packaged_data_is_unavailable(
-    mocker, monkeypatch
-) -> None:
-    """The resolver should fall back to the known site-packages path."""
-    fallback_path = (
-        "/usr/local/lib/python3.12/site-packages/industrial_classification/data/"
-        "example_sic_lookup_data.csv"
-    )
-    monkeypatch.delenv("SIC_LOOKUP_DATA_PATH", raising=False)
-    mocker.patch(
-        "sic_classification_vector_store.utils.sayt.resources.files",
-        side_effect=ImportError("packaged data unavailable"),
-    )
-    mock_warning = mocker.patch(
-        "sic_classification_vector_store.utils.sayt.logger.warning"
-    )
-
-    assert resolve_sayt_data_path() == fallback_path
-    mock_warning.assert_called_once_with(
-        "Could not resolve packaged SIC SAYT data, using fallback",
-        data_path=fallback_path,
-        error="packaged data unavailable",
-    )
-
-
-def test_load_builds_suggester(mocker) -> None:
-    """The manager should build the SAYT suggester from the resolved CSV path."""
-    expected_path = "/resolved/example_sic_lookup_data.csv"
-    mock_resolve = mocker.patch(
-        "sic_classification_vector_store.utils.sayt.resolve_sayt_data_path",
-        return_value=expected_path,
+    mock_files = mocker.patch(
+        "sic_classification_vector_store.utils.sayt.resources.files"
     )
     mock_from_csv = mocker.patch(
         "sic_classification_vector_store.utils.sayt.SAYTSuggester.from_csv"
@@ -78,9 +24,145 @@ def test_load_builds_suggester(mocker) -> None:
 
     manager.load()
 
-    mock_resolve.assert_called_once_with()
+    mock_files.assert_not_called()
+    mock_from_csv.assert_called_once_with(
+        "/configured/sayt.csv",
+        search_text_col="description",
+        display_text_col="description",
+    )
+
+
+def test_load_uses_packaged_data_when_available(mocker, tmp_path, monkeypatch) -> None:
+    """The manager should fall back to packaged data when no override is supplied."""
+    packaged_data_dir = tmp_path / "package" / "data"
+    packaged_data_dir.mkdir(parents=True)
+    expected_path = packaged_data_dir / "example_sic_lookup_data.csv"
+    expected_path.write_text("description\nStreet lighting installation\n")
+    monkeypatch.delenv("SIC_LOOKUP_DATA_PATH", raising=False)
+
+    mocker.patch(
+        "sic_classification_vector_store.utils.sayt.resources.files",
+        return_value=packaged_data_dir,
+    )
+    mocker.patch(
+        "sic_classification_vector_store.utils.sayt.resources.as_file",
+        return_value=nullcontext(expected_path),
+    )
+    mock_info = mocker.patch("sic_classification_vector_store.utils.sayt.logger.info")
+    mock_from_csv = mocker.patch(
+        "sic_classification_vector_store.utils.sayt.SAYTSuggester.from_csv"
+    )
+
+    manager = SaytManager()
+
+    manager.load()
+
     mock_from_csv.assert_called_once_with(
         expected_path,
+        search_text_col="description",
+        display_text_col="description",
+    )
+    mock_info.assert_any_call(
+        "Using packaged SIC SAYT data",
+        data_path=str(expected_path),
+    )
+
+
+def test_load_raises_when_packaged_data_is_unavailable(mocker, monkeypatch) -> None:
+    """The manager should fail with a clear override message."""
+    monkeypatch.delenv("SIC_LOOKUP_DATA_PATH", raising=False)
+    mocker.patch(
+        "sic_classification_vector_store.utils.sayt.resources.files",
+        side_effect=ImportError("packaged data unavailable"),
+    )
+    mock_warning = mocker.patch(
+        "sic_classification_vector_store.utils.sayt.logger.warning"
+    )
+    message = (
+        "Could not resolve packaged SIC SAYT data. "
+        "Set SIC_LOOKUP_DATA_PATH to override the CSV path."
+    )
+    manager = SaytManager()
+
+    with pytest.raises(RuntimeError, match=message):
+        manager.load()
+
+    mock_warning.assert_called_once_with(
+        message,
+        error="packaged data unavailable",
+    )
+
+
+def test_load_raises_when_packaged_file_is_missing(mocker, monkeypatch) -> None:
+    """The manager should fail when the packaged CSV resource is missing."""
+    packaged_data_dir = Path("/package/data")
+    expected_path = packaged_data_dir / "example_sic_lookup_data.csv"
+    monkeypatch.delenv("SIC_LOOKUP_DATA_PATH", raising=False)
+    mocker.patch(
+        "sic_classification_vector_store.utils.sayt.resources.files",
+        return_value=packaged_data_dir,
+    )
+    mock_warning = mocker.patch(
+        "sic_classification_vector_store.utils.sayt.logger.warning"
+    )
+    message = (
+        "Packaged SIC SAYT data not found. "
+        "Set SIC_LOOKUP_DATA_PATH to override the CSV path."
+    )
+    manager = SaytManager()
+
+    with pytest.raises(RuntimeError, match=message):
+        manager.load()
+
+    mock_warning.assert_called_once_with(message, data_path=str(expected_path))
+
+
+def test_load_builds_suggester(mocker) -> None:
+    """The manager should build the SAYT suggester from the resolved CSV path."""
+    expected_path = "/resolved/example_sic_lookup_data.csv"
+    mocker.patch(
+        "sic_classification_vector_store.utils.sayt.resources.files",
+        return_value=Path("/package/data"),
+    )
+    mock_is_file = mocker.patch(
+        "pathlib.Path.is_file",
+        return_value=True,
+    )
+    mocker.patch(
+        "sic_classification_vector_store.utils.sayt.resources.as_file",
+        return_value=nullcontext(Path(expected_path)),
+    )
+    mock_from_csv = mocker.patch(
+        "sic_classification_vector_store.utils.sayt.SAYTSuggester.from_csv"
+    )
+
+    manager = SaytManager()
+
+    manager.load()
+
+    mock_is_file.assert_called_once_with()
+    mock_from_csv.assert_called_once_with(
+        Path(expected_path),
+        search_text_col="description",
+        display_text_col="description",
+    )
+
+
+def test_load_prefers_explicit_data_path_over_packaged_resource(mocker) -> None:
+    """An explicit data path should bypass packaged-resource resolution."""
+    mock_files = mocker.patch(
+        "sic_classification_vector_store.utils.sayt.resources.files"
+    )
+    mock_from_csv = mocker.patch(
+        "sic_classification_vector_store.utils.sayt.SAYTSuggester.from_csv"
+    )
+    manager = SaytManager("/configured/sayt.csv")
+
+    manager.load()
+
+    mock_files.assert_not_called()
+    mock_from_csv.assert_called_once_with(
+        "/configured/sayt.csv",
         search_text_col="description",
         display_text_col="description",
     )

--- a/tests/test_sayt_manager.py
+++ b/tests/test_sayt_manager.py
@@ -1,0 +1,139 @@
+"""Unit tests for the SIC SAYT manager."""
+
+from pathlib import Path
+
+import pytest
+
+from sic_classification_vector_store.utils.sayt import (
+    SaytManager,
+    create_sayt_manager,
+    resolve_sayt_data_path,
+)
+
+pytestmark = pytest.mark.utils
+
+
+def test_resolve_sayt_data_path_prefers_env_var(monkeypatch) -> None:
+    """The resolver should prefer a non-empty environment override."""
+    monkeypatch.setenv("SIC_LOOKUP_DATA_PATH", "  /configured/sayt.csv  ")
+
+    assert resolve_sayt_data_path() == "/configured/sayt.csv"
+
+
+def test_resolve_sayt_data_path_uses_packaged_data_when_available(
+    mocker, monkeypatch
+) -> None:
+    """The resolver should return the packaged CSV path when it is available."""
+    packaged_data_dir = Path("/package/data")
+    monkeypatch.delenv("SIC_LOOKUP_DATA_PATH", raising=False)
+    mocker.patch(
+        "sic_classification_vector_store.utils.sayt.resources.files",
+        return_value=packaged_data_dir,
+    )
+    mock_info = mocker.patch("sic_classification_vector_store.utils.sayt.logger.info")
+
+    assert resolve_sayt_data_path() == "/package/data/example_sic_lookup_data.csv"
+    mock_info.assert_called_once_with(
+        "Using packaged SIC SAYT data",
+        data_path="/package/data/example_sic_lookup_data.csv",
+    )
+
+
+def test_resolve_sayt_data_path_falls_back_when_packaged_data_is_unavailable(
+    mocker, monkeypatch
+) -> None:
+    """The resolver should fall back to the known site-packages path."""
+    fallback_path = (
+        "/usr/local/lib/python3.12/site-packages/industrial_classification/data/"
+        "example_sic_lookup_data.csv"
+    )
+    monkeypatch.delenv("SIC_LOOKUP_DATA_PATH", raising=False)
+    mocker.patch(
+        "sic_classification_vector_store.utils.sayt.resources.files",
+        side_effect=ImportError("packaged data unavailable"),
+    )
+    mock_warning = mocker.patch(
+        "sic_classification_vector_store.utils.sayt.logger.warning"
+    )
+
+    assert resolve_sayt_data_path() == fallback_path
+    mock_warning.assert_called_once_with(
+        "Could not resolve packaged SIC SAYT data, using fallback",
+        data_path=fallback_path,
+        error="packaged data unavailable",
+    )
+
+
+def test_load_builds_suggester(mocker) -> None:
+    """The manager should build the SAYT suggester from the resolved CSV path."""
+    expected_path = "/resolved/example_sic_lookup_data.csv"
+    mock_resolve = mocker.patch(
+        "sic_classification_vector_store.utils.sayt.resolve_sayt_data_path",
+        return_value=expected_path,
+    )
+    mock_from_csv = mocker.patch(
+        "sic_classification_vector_store.utils.sayt.SAYTSuggester.from_csv"
+    )
+
+    manager = SaytManager()
+
+    manager.load()
+
+    mock_resolve.assert_called_once_with()
+    mock_from_csv.assert_called_once_with(
+        expected_path,
+        search_text_col="description",
+        display_text_col="description",
+    )
+
+
+def test_suggest_requires_ready_manager() -> None:
+    """The manager should reject requests until the suggester is ready."""
+    manager = SaytManager()
+
+    try:
+        manager.suggest("street")
+    except RuntimeError as exc:
+        assert str(exc) == "SAYT suggester is not ready"
+    else:
+        raise AssertionError("Expected RuntimeError when SAYT manager is not ready")
+
+
+def test_suggest_surfaces_load_error() -> None:
+    """The manager should surface startup failures before serving suggestions."""
+    manager = SaytManager()
+    manager.load_error = "csv missing"
+
+    with pytest.raises(
+        RuntimeError, match="SAYT suggester failed to load: csv missing"
+    ):
+        manager.suggest("street")
+
+
+def test_suggest_requires_loaded_suggester_when_ready() -> None:
+    """The manager should reject requests if readiness is set without a suggester."""
+    manager = SaytManager()
+    manager.ready_event.set()
+
+    with pytest.raises(RuntimeError, match="SAYT suggester not loaded"):
+        manager.suggest("street")
+
+
+def test_suggest_uses_loaded_suggester(mocker) -> None:
+    """The manager should delegate suggestions to the warmed suggester."""
+    manager = SaytManager()
+    manager.ready_event.set()
+    manager.suggester = mocker.Mock()
+    manager.suggester.suggest.return_value = ["Street lighting installation"]
+
+    result = manager.suggest("street", 2)
+
+    assert result == ["Street lighting installation"]
+    manager.suggester.suggest.assert_called_once_with("street", 2)
+
+
+def test_create_sayt_manager_normalises_path_objects() -> None:
+    """The manager factory should normalise path-like input."""
+    manager = create_sayt_manager(Path("/resolved/example_sic_lookup_data.csv"))
+
+    assert manager.data_path == "/resolved/example_sic_lookup_data.csv"

--- a/tests/test_sayt_route.py
+++ b/tests/test_sayt_route.py
@@ -31,7 +31,7 @@ async def test_lifespan_yields_sayt_manager_in_state(mocker) -> None:
     """The app lifespan should share the warmed manager through request state."""
     mock_manager = MagicMock()
     mocker.patch(
-        "sic_classification_vector_store.api.main.create_sayt_manager",
+        "sic_classification_vector_store.api.main.SaytManager",
         return_value=mock_manager,
     )
     mock_start = mocker.patch("sic_classification_vector_store.api.main.Thread.start")

--- a/tests/test_sayt_route.py
+++ b/tests/test_sayt_route.py
@@ -51,7 +51,7 @@ def test_get_sayt_manager_reads_from_request_state() -> None:
     assert get_sayt_manager(request) is mock_manager
 
 
-def test_sayt_endpoint_returns_suggestions(mocker) -> None:
+def test_sayt_endpoint_returns_suggestions() -> None:
     """The route should return suggester results from the service layer."""
     mock_manager = MagicMock()
     mock_manager.suggest.return_value = [
@@ -73,7 +73,7 @@ def test_sayt_endpoint_returns_suggestions(mocker) -> None:
     mock_manager.suggest.assert_called_once_with("street", 2)
 
 
-def test_sayt_endpoint_returns_service_unavailable(mocker) -> None:
+def test_sayt_endpoint_returns_service_unavailable() -> None:
     """The route should surface manager readiness failures as 503 responses."""
     mock_manager = MagicMock()
     mock_manager.suggest.side_effect = RuntimeError("SAYT suggester is not ready")

--- a/tests/test_sayt_route.py
+++ b/tests/test_sayt_route.py
@@ -1,0 +1,121 @@
+"""Tests for the SIC vector-store SAYT endpoint."""
+
+from collections.abc import Generator
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sic_classification_vector_store.api.main import app, lifespan
+from sic_classification_vector_store.api.routes.v1.sayt import get_sayt_manager
+
+pytestmark = pytest.mark.api
+
+
+@pytest.fixture(autouse=True)
+def clear_dependency_overrides() -> Generator[None, None, None]:
+    """Ensure dependency overrides do not leak between route tests."""
+    app.dependency_overrides.clear()
+    yield
+    app.dependency_overrides.clear()
+
+
+def _setup_sayt_override(mock_manager) -> None:
+    """Override the route dependency with a supplied SAYT manager."""
+    app.dependency_overrides[get_sayt_manager] = lambda: mock_manager
+
+
+@pytest.mark.asyncio
+async def test_lifespan_yields_sayt_manager_in_state(mocker) -> None:
+    """The app lifespan should share the warmed manager through request state."""
+    mock_manager = MagicMock()
+    mocker.patch(
+        "sic_classification_vector_store.api.main.create_sayt_manager",
+        return_value=mock_manager,
+    )
+    mock_start = mocker.patch("sic_classification_vector_store.api.main.Thread.start")
+
+    async with lifespan(app) as state:
+        assert state == {"sayt_manager": mock_manager}
+
+    assert mock_start.call_count == 2  # noqa: PLR2004
+
+
+def test_get_sayt_manager_reads_from_request_state() -> None:
+    """The route dependency should read the warmed manager from request state."""
+    mock_manager = MagicMock()
+    request = MagicMock()
+    request.state.sayt_manager = mock_manager
+
+    assert get_sayt_manager(request) is mock_manager
+
+
+def test_sayt_endpoint_returns_suggestions(mocker) -> None:
+    """The route should return suggester results from the service layer."""
+    mock_manager = MagicMock()
+    mock_manager.suggest.return_value = [
+        "Street lighting installation",
+        "Insulating activities",
+    ]
+    _setup_sayt_override(mock_manager)
+    client = TestClient(app)
+
+    response = client.get(
+        "/v1/sic-vector-store/sayt",
+        params={"description": "street", "num_suggestions": "2"},
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() == {
+        "suggestions": ["Street lighting installation", "Insulating activities"]
+    }
+    mock_manager.suggest.assert_called_once_with("street", 2)
+
+
+def test_sayt_endpoint_returns_service_unavailable(mocker) -> None:
+    """The route should surface manager readiness failures as 503 responses."""
+    mock_manager = MagicMock()
+    mock_manager.suggest.side_effect = RuntimeError("SAYT suggester is not ready")
+    _setup_sayt_override(mock_manager)
+    client = TestClient(app)
+
+    response = client.get(
+        "/v1/sic-vector-store/sayt",
+        params={"description": "street"},
+    )
+
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert response.json() == {"detail": "SAYT suggester is not ready"}
+
+
+def test_sayt_endpoint_returns_internal_server_error() -> None:
+    """The route should wrap unexpected suggester errors as 500 responses."""
+    mock_manager = MagicMock()
+    mock_manager.suggest.side_effect = ValueError("boom")
+    _setup_sayt_override(mock_manager)
+    client = TestClient(app)
+
+    response = client.get(
+        "/v1/sic-vector-store/sayt",
+        params={"description": "street"},
+    )
+
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert response.json() == {"detail": "Error retrieving SIC SAYT suggestions: boom"}
+    mock_manager.suggest.assert_called_once_with("street", None)
+
+
+def test_sayt_endpoint_rejects_empty_description() -> None:
+    """The route should reject empty descriptions."""
+    mock_manager = MagicMock()
+    _setup_sayt_override(mock_manager)
+    client = TestClient(app)
+
+    response = client.get(
+        "/v1/sic-vector-store/sayt",
+        params={"description": ""},
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json() == {"detail": "Description cannot be empty"}

--- a/tests/test_status_route.py
+++ b/tests/test_status_route.py
@@ -2,16 +2,19 @@
 
 from threading import Event
 from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 
 from sic_classification_vector_store.api.models.status import StatusResponse
 from sic_classification_vector_store.api.routes.v1.status import (
     _resolve_file_source,
-    _resolve_status,
+    _resolve_manager_status,
+    get_sayt_manager,
     get_status,
     get_vector_store,
 )
+from sic_classification_vector_store.utils.sayt import SaytManager
 from sic_classification_vector_store.utils.vector_store import (
     VectorStoreManager,
 )
@@ -33,18 +36,45 @@ def _make_vector_store_manager(
     return vector_store_manager
 
 
+def _make_sayt_manager(
+    *, ready: bool, suggester: object | None = None, load_error: str | None = None
+) -> SaytManager:
+    """Build a SAYT manager for status resolution tests."""
+    sayt_manager = SaytManager("/resolved/example_sic_lookup_data.csv")
+    sayt_manager.ready_event = Event()
+    if ready:
+        sayt_manager.ready_event.set()
+    sayt_manager.suggester = cast(Any, suggester)
+    sayt_manager.load_error = load_error
+    return sayt_manager
+
+
 def test_resolve_status_returns_loading_while_vector_store_initialises() -> None:
     """The status should remain loading until the embedder is ready."""
     vector_store_manager = _make_vector_store_manager(ready=False)
 
-    assert _resolve_status(vector_store_manager) == "loading"
+    assert (
+        _resolve_manager_status(
+            is_ready=vector_store_manager.ready_event.is_set(),
+            loaded_value=vector_store_manager.embed,
+            load_error=vector_store_manager.load_error,
+        )
+        == "loading"
+    )
 
 
 def test_resolve_status_returns_ready_after_successful_load() -> None:
     """The status should be ready once the embedder is available."""
     vector_store_manager = _make_vector_store_manager(ready=True, embed=object())
 
-    assert _resolve_status(vector_store_manager) == "ready"
+    assert (
+        _resolve_manager_status(
+            is_ready=vector_store_manager.ready_event.is_set(),
+            loaded_value=vector_store_manager.embed,
+            load_error=vector_store_manager.load_error,
+        )
+        == "ready"
+    )
 
 
 def test_resolve_status_returns_error_after_failed_load() -> None:
@@ -54,12 +84,73 @@ def test_resolve_status_returns_error_after_failed_load() -> None:
         load_error="failed to load vector store",
     )
 
-    assert _resolve_status(vector_store_manager) == "error"
+    assert (
+        _resolve_manager_status(
+            is_ready=vector_store_manager.ready_event.is_set(),
+            loaded_value=vector_store_manager.embed,
+            load_error=vector_store_manager.load_error,
+        )
+        == "error"
+    )
+
+
+def test_resolve_sayt_status_returns_loading_while_suggester_initialises() -> None:
+    """The SAYT status should remain loading until the suggester is ready."""
+    sayt_manager = _make_sayt_manager(ready=False)
+
+    assert (
+        _resolve_manager_status(
+            is_ready=sayt_manager.ready_event.is_set(),
+            loaded_value=sayt_manager.suggester,
+            load_error=sayt_manager.load_error,
+        )
+        == "loading"
+    )
+
+
+def test_resolve_sayt_status_returns_ready_after_successful_load() -> None:
+    """The SAYT status should be ready once the suggester is available."""
+    sayt_manager = _make_sayt_manager(ready=True, suggester=object())
+
+    assert (
+        _resolve_manager_status(
+            is_ready=sayt_manager.ready_event.is_set(),
+            loaded_value=sayt_manager.suggester,
+            load_error=sayt_manager.load_error,
+        )
+        == "ready"
+    )
+
+
+def test_resolve_sayt_status_returns_error_after_failed_load() -> None:
+    """The SAYT status should surface startup failures instead of reporting ready."""
+    sayt_manager = _make_sayt_manager(
+        ready=True,
+        load_error="failed to load sayt suggester",
+    )
+
+    assert (
+        _resolve_manager_status(
+            is_ready=sayt_manager.ready_event.is_set(),
+            loaded_value=sayt_manager.suggester,
+            load_error=sayt_manager.load_error,
+        )
+        == "error"
+    )
 
 
 def test_get_vector_store_returns_singleton_manager() -> None:
     """The route dependency should expose the shared vector store manager."""
     assert get_vector_store() is singleton_vector_store_manager
+
+
+def test_get_sayt_manager_reads_from_request_state() -> None:
+    """The route dependency should read the warmed SAYT manager from request state."""
+    mock_manager = MagicMock()
+    request = MagicMock()
+    request.state.sayt_manager = mock_manager
+
+    assert get_sayt_manager(request) is mock_manager
 
 
 @pytest.mark.asyncio
@@ -69,6 +160,7 @@ async def test_get_status_returns_status_response() -> None:
     expected_index_size = 16618
 
     vector_store_manager = _make_vector_store_manager(ready=True, embed=object())
+    sayt_manager = _make_sayt_manager(ready=True, suggester=object())
     vector_store_manager.status = {
         "embedding_model_name": "all-MiniLM-L6-v2",
         "db_dir": "src/sic_classification_vector_store/data/vector_store",
@@ -88,10 +180,11 @@ async def test_get_status_returns_status_response() -> None:
         "index_size": expected_index_size,
     }
 
-    result = await get_status(vector_store_manager)
+    result = await get_status(vector_store_manager, sayt_manager)
 
     assert isinstance(result, StatusResponse)
-    assert result.status == "ready"
+    assert result.vector_store_status == "ready"
+    assert result.sayt_status == "ready"
     assert result.embedding_model_name == "all-MiniLM-L6-v2"
     assert result.db_dir == "src/sic_classification_vector_store/data/vector_store"
     assert (


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

This PR wires the `SAYTSuggester` class into the vector store API as introduced in PR [#61](https://github.com/ONSdigital/sic-classification-utils/pull/61) in `sic-classification-utils`.

## 📜 Changes Introduced

- Use v0.1.11 of `sic-classification-utils`, which includes the `SAYTSuggester` class
- New model for the SAYT endpoint response
- New endpoint `/v1/sic-vector-store/sayt` to get SAYT suggestions
- Loading of the SAYT suggester class and related corpus into the app lifespan in the background
- Updating of dependencies to use newer versions of `FastAPI` (dependabot flags a vulnerability in a transitive dependency `starlette`)

- [x] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [ ] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

Run the app as normal:

```bash
make run-vector-store
```

Go to the docs/API testing page at http://0.0.0.0:8088/docs. Confirm the new `/v1/sic-vector-store/sayt` endpoint is there.

Try out the new endpoint, entering a suggestion that is >3 characters.
